### PR TITLE
Fix cookie expires

### DIFF
--- a/src/lib/components/auth/Login.svelte
+++ b/src/lib/components/auth/Login.svelte
@@ -42,9 +42,13 @@
 
       //クッキー書き込む
       document.cookie =
-        "userId=" + dat.data.UserInfo.userId + "; SameSite=strict;";
+        "userId=" +
+        dat.data.UserInfo.userId +
+        "; SameSite=strict; Max-Age=1296000";
       document.cookie =
-        "sessionId=" + dat.data.sessionId + "; SameSite=strict;";
+        "sessionId=" +
+        dat.data.sessionId +
+        "; SameSite=strict; Max-Age=1296000";
 
       // チャンネル情報とチャンネル一覧を取得するイベントを発火
       socket.emit("fetchUserInfo", {


### PR DESCRIPTION
ログインした後に残したクッキーが、ブラウザを閉じると消える仕様になっていた。
それの修正として期限を１５日に設定して残すようにした。（１５日という基準はおぼろげに浮かんできたから）